### PR TITLE
chore(release): derive the repo slug from the git remote

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -65,6 +65,32 @@ function parseRepoSlug(repositoryField: string): string {
     .replace(/\/$/, '');
 }
 
+/**
+ * Resolves the `owner/repo` slug the GitHub release should target.
+ *
+ * Derived from the `origin` remote rather than from `package/package.json` → `repository`, because
+ * in the template (`mantine-base-component`) that field still points at `gfazioli/mantine-led` by
+ * design — `rename-mantine-component` rewrites it only when a real component is bootstrapped. Read
+ * from package.json, every template release aimed at the LED repo and died with
+ * `HTTP 422 … Release.tag_name already exists`, since the LED's own history owns those low version
+ * numbers. That also aborted `release:patch` before `docs:deploy` could run.
+ *
+ * Falls back to the package.json field if there is no `origin` remote.
+ */
+async function resolveRepoSlug(): Promise<string> {
+  const remotes = await git.getRemotes(true);
+  const originUrl = remotes.find((remote) => remote.name === 'origin')?.refs?.push;
+
+  if (originUrl) {
+    return parseRepoSlug(originUrl);
+  }
+
+  signale.warn(
+    `No ${chalk.cyan('origin')} remote found — falling back to ${chalk.cyan('package/package.json')} repository field.`
+  );
+  return parseRepoSlug(packageJson.repository.url || packageJson.repository);
+}
+
 const packageJsonPath = path.join(process.cwd(), 'package/package.json');
 const packageJson = fs.readJsonSync(packageJsonPath);
 const { argv } = yargs(hideBin(process.argv)) as any;
@@ -158,7 +184,7 @@ async function release() {
   await git.push();
 
   const changelogBody = extractChangelogBody(path.join(process.cwd(), 'CHANGELOG.md'));
-  const repoSlug = parseRepoSlug(packageJson.repository.url || packageJson.repository);
+  const repoSlug = await resolveRepoSlug();
 
   const tags = await git.tags();
   const previousTag = tags.all.includes(nextVersion)


### PR DESCRIPTION
## Summary

Propagated from `mantine-base-component`: `release.ts` now derives the `owner/repo` slug for the GitHub release from the `origin` remote instead of `package/package.json` → `repository`, falling back to the package.json field if no remote exists.

**Functional no-op for this repo** — its `repository` field is already correct and resolves to the same slug (verified against the real remotes before propagating). The change matters for the template, where that field still points at `gfazioli/mantine-led` by design, so every template release targeted the wrong repository and died with `HTTP 422 … Release.tag_name already exists` — which also aborted `release:patch` before `docs:deploy` could run.

Kept in sync so the template and the component repos don't drift.

## Test plan
- [x] yarn test (syncpack + format + typecheck + lint + jest)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release creation by detecting the repository from the Git remote when available.
  * Added a fallback to package metadata when the remote repository cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->